### PR TITLE
Fix incorrect comment in src/tools/transforms3d.py

### DIFF
--- a/src/tools/transforms3d.py
+++ b/src/tools/transforms3d.py
@@ -201,7 +201,7 @@ def change_for(p, R, T=0, forward=True):
     """
     if forward:  # R.T @ (p_global - pelvis_translation)
         return torch.einsum('...di,...d->...i', R, p - T)
-    else:  # R @ (p_global - pelvis_translation)
+    else:  # R @ p_global + pelvis_translation
         return torch.einsum('...di,...i->...d', R, p) + T
 
 def get_z_rot(rot_, in_format="6d"):


### PR DESCRIPTION
The inline comment in the else branch of function change_for currently states:

    # R @ (p_global - pelvis_translation)

However, the implementation computes:

    R p + T

This PR corrects the comment to match the actual computation.
No functional changes were made.